### PR TITLE
Use another slicing method

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function getSafe(fn, defaultVal) {
         return fn();
     } catch (e) {
         const string = fn.toString();
-        const search = string.substr(21, string.length - 24);
+        const search = string.slice(string.indexOf('.') + 1);
         console.warn('getSafe cant get:', search);
         return defaultVal;
     }


### PR DESCRIPTION
The current method only allows correct slicing if the variable name is three characters long and the syntax `() => `  is being used letter by letter (or if you change one in a way that decreases the number of characters and vice versa)